### PR TITLE
bug: Update repo for recent rust versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "howto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-ngx = "0.3.0-beta"
+ngx = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 `cargo build`
 
+NOTE: it may be necessary to explicitly set versions of dependent software. For example, to build with a newer, more recent zlib version you can run `ZLIB_VERSION=1.3.1 cargo build`. See the `ngx-rust` README.md for details.
+
 ### Running
 
 A basic configuration file is provided in the `conf` directory. Once you've built the project you'll have a usable object in the `target/debug` directory, move this to your desired location and update the `conf/howto.con` file with the proper path and name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use ngx::http::{HTTPModule, MergeConfigError};
 use ngx::{core, core::Status, http};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_modules, ngx_null_command, ngx_string};
 use std::os::raw::{c_char, c_void};
+use std::ptr::addr_of;
 
 struct Module;
 
@@ -19,7 +20,7 @@ impl http::HTTPModule for Module {
     type LocConf = ModuleConfig;
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        let htcf = http::ngx_http_conf_get_module_main_conf(cf, &ngx_http_core_module);
+        let htcf = http::ngx_http_conf_get_module_main_conf(cf, &*addr_of!(ngx_http_core_module));
 
         let h = ngx_array_push(
             &mut (*htcf).phases[ngx_http_phases_NGX_HTTP_ACCESS_PHASE as usize].handlers,
@@ -151,7 +152,7 @@ extern "C" fn ngx_http_howto_commands_set_method(
 //
 // The function body is implemented as a Rust closure.
 http_request_handler!(howto_access_handler, |request: &mut http::Request| {
-    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(&ngx_http_howto_module) };
+    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(&*addr_of!(ngx_http_howto_module)) };
     let co = co.expect("module config is none");
 
     ngx_log_debug_http!(request, "howto module enabled called");


### PR DESCRIPTION
Add note about explicitly setting dependency versions.
Use addr_of before it becomes an error and requirement.
Use latest release of ngx-rust.